### PR TITLE
QDB-2999 - Add support for GetLastError().

### DIFF
--- a/Quasardb.Native/qdb_api.cs
+++ b/Quasardb.Native/qdb_api.cs
@@ -60,6 +60,11 @@ namespace Quasardb.Native
             [In] pointer_t buffer);
 
         [DllImport(DLL_NAME, CallingConvention = CALL_CONV)]
+        public static extern qdb_error qdb_get_last_error(
+            [Out] out qdb_error error,
+            [Out] out qdb_sized_string message);
+
+        [DllImport(DLL_NAME, CallingConvention = CALL_CONV)]
         public static extern qdb_error qdb_get_type(
             [In] qdb_handle handle,
             [In] [MarshalAs(ALIAS_TYPE)] string alias,

--- a/Quasardb.Native/qdb_error.cs
+++ b/Quasardb.Native/qdb_error.cs
@@ -53,6 +53,14 @@ namespace Quasardb.Native
         qdb_e_no_space_left = 0xf3000033,
         qdb_e_quota_exceeded = 0xf2000034,
         qdb_e_alias_too_long = 0xc2000035,
-        qdb_e_column_not_found = 0xb1000039
+        qdb_e_column_not_found = 0xb1000039,
+        qdb_e_query_too_complex = 0xb2000040,
+        qdb_e_invalid_crypto_key = 0xc2000041,
+        qdb_e_invalid_query = 0xc2000042,
+        qdb_e_invalid_regex = 0xc2000043,
+        qdb_e_unknown_user = 0xc2000044,
+        qdb_e_interrupted = 0xf2000045,
+        qdb_e_network_inbuf_too_small = 0xe2000046,
+        qdb_e_network_error = 0xd2000047
     }
 }

--- a/Quasardb.Tests/Cluster/Misc.cs
+++ b/Quasardb.Tests/Cluster/Misc.cs
@@ -124,5 +124,30 @@ namespace Quasardb.Tests.Cluster
         {
             QdbTestCluster.Instance.SetCompression(Quasardb.QdbCompression.Best);
         }
+
+        [TestMethod]
+        public void GetLastErrorForNullQuery()
+        {
+            try
+            {
+                QdbTestCluster.Instance.Query(null);
+            }
+            catch (QdbQueryException)
+            {
+                Assert.AreEqual("at qdb_query: Got NULL query", QdbTestCluster.Instance.GetLastError());
+            }
+        }
+
+        [TestMethod]
+        public void GetLastErrorForInvalidQuery() {
+            try
+            {
+                QdbTestCluster.Instance.Query("a non query");
+            }
+            catch (QdbQueryException)
+            {
+                Assert.AreEqual("at qdb_query: The provided query is invalid.", QdbTestCluster.Instance.GetLastError());
+            }
+        }
     }
-}
+} // namespace Cluster

--- a/Quasardb.Tests/Query/Query.cs
+++ b/Quasardb.Tests/Query/Query.cs
@@ -103,7 +103,7 @@ namespace Quasardb.Tests.Query
         #region Query failure tests
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [ExpectedException(typeof(QdbQueryException))]
         public void ThrowsForNullQuery()
         {
             _cluster.Query(null);

--- a/Quasardb/QdbCluster.cs
+++ b/Quasardb/QdbCluster.cs
@@ -264,8 +264,6 @@ namespace Quasardb
         /// <seealso cref="QdbQueryResult"/>
         public QdbQueryResult Query(string query)
         {
-            if (query == null) throw new ArgumentNullException(nameof(query));
-
             return new QdbQueryResult(_handle, query);
         }
     }

--- a/Quasardb/QdbCluster.cs
+++ b/Quasardb/QdbCluster.cs
@@ -78,6 +78,18 @@ namespace Quasardb
         }
 
         /// <summary>
+        /// Gets the last API error description.
+        /// <returns>A message describing the error occurred during the last operation.</returns>
+        /// </summary>
+        public string GetLastError()
+        {
+            qdb_error error;
+            qdb_sized_string message;
+            qdb_api.qdb_get_last_error(out error, out message);
+            return message.ToString();
+        }
+
+        /// <summary>
         /// Set the compression level.
         /// </summary>
         /// <param name="level">The level of compression to be used for the current handle to cluster.</param>


### PR DESCRIPTION
I only return the error message here, but I think that we need to modify the error handling so that the user be able to get the exact error code. It should be an easy change but touching all the exception handling stuff (so lots of almost automatic changes).