### PR TITLE
[QDB-18219] - Remove Win32 build references from .NET project files

### DIFF
--- a/Quasardb/Quasardb.csproj
+++ b/Quasardb/Quasardb.csproj
@@ -35,11 +35,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Update="win32\qdb_api.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <None Update="win64\qdb_api.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Quasardb/Quasardb.nuspec
+++ b/Quasardb/Quasardb.nuspec
@@ -15,7 +15,6 @@
     <files>
         <file src="quasardb.targets" target="build\quasardb.targets" />
         <file src="bin\Release\netstandard2.0\linux\libqdb_api.so" target="linux\libqdb_api.so" />
-        <file src="bin\Release\netstandard2.0\win32\qdb_api.dll" target="win32\qdb_api.dll" />
         <file src="bin\Release\netstandard2.0\win64\qdb_api.dll" target="win64\qdb_api.dll" />
     </files>
 </package>

--- a/Quasardb/quasardb.targets
+++ b/Quasardb/quasardb.targets
@@ -6,12 +6,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\..\win32\qdb_api.dll">
-      <Link>win32\qdb_api.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
    <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\..\win64\qdb_api.dll">
         <Link>win64\qdb_api.dll</Link>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Create and update an atomic integer:
 Download the following files to your local copy of the repository:
 
 * `Quasardb\linux\libqdb_api.so` from [qdb-X.X.X-linux-64bit-c-api.zip](https://download.quasardb.net/quasardb/)
-* `Quasardb\win32\qdb_api.dll` from [qdb-X.X.X-windows-32bit-c-api.zip](https://download.quasardb.net/quasardb/)
 * `Quasardb\win64\qdb_api.dll` from [qdb-X.X.X-windows-64bit-c-api.zip](https://download.quasardb.net/quasardb/)
 
 Open the solution `Quasardb.sln` in Visual Studio.


### PR DESCRIPTION
Teamcity build: http://teamcity.cicd.intra.quasar.ai:8111/buildConfiguration/Api_DotNET_Windows_Composite/1171459